### PR TITLE
Adding Plugin Descriptor

### DIFF
--- a/milkman-plugin.json
+++ b/milkman-plugin.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    {
+      "author": "Lars Opitz",
+      "name": "milkman-themes",
+      "artifact": "milkman-themes.jar",
+      "description": "Contains 5 new UI themes: Console Dark, Dark Violet, Deep Ocean, Dracula, GitHub Dark"
+    }
+  ]
+}


### PR DESCRIPTION
To be picked up in the new marketplace (https://github.com/warmuuh/milkman/blob/master/docs/features.md#marketplace), this descriptor file is needed.